### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/liquibase/CLI.java
+++ b/src/main/java/io/kestra/plugin/liquibase/CLI.java
@@ -52,10 +52,10 @@ import lombok.experimental.SuperBuilder;
                         liquibase diff
                         --url="jdbc:postgresql://pg1:5432/demo1"
                         --username=user1
-                        --password=pass1
+                        --password={{ secret('DB_PASSWORD') }}
                         --reference-url="jdbc:postgresql://pg2:5432/demo2"
                         --reference-username=user2
-                        --reference-password=pass2
+                        --reference-password={{ secret('REFERENCE_DB_PASSWORD') }}
                 """
         ),
         @Example(
@@ -80,7 +80,7 @@ import lombok.experimental.SuperBuilder;
                         liquibase snapshot
                         --url=jdbc:postgresql://pg1:5432/demo1
                         --username=user1
-                        --password=pass1
+                        --password={{ secret('DB_PASSWORD') }}
                         --output-file=snapshot.xml
                 """
         ),
@@ -116,7 +116,7 @@ import lombok.experimental.SuperBuilder;
                         liquibase update
                         --url="jdbc:postgresql://pg1:5432/demo1"
                         --username=user1
-                        --password=pass1
+                        --password={{ secret('DB_PASSWORD') }}
                         --changeLogFile=changelog.yaml
                 """
         )

--- a/src/main/java/io/kestra/plugin/liquibase/Diff.java
+++ b/src/main/java/io/kestra/plugin/liquibase/Diff.java
@@ -1,6 +1,8 @@
 package io.kestra.plugin.liquibase;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
@@ -75,10 +77,12 @@ public class Diff extends AbstractExecScript implements RunnableTask<ScriptOutpu
 
     @Schema(title = "Target username", description = "Authentication for the target database; empty means driver default")
     @PluginProperty(secret = true, group = "connection")
+    @ToString.Exclude
     private Property<String> username;
 
     @Schema(title = "Target password", description = "Password for the target user; stored as plain value in the task run")
     @PluginProperty(secret = true, group = "connection")
+    @ToString.Exclude
     private Property<String> password;
 
     @Schema(title = "Reference JDBC URL", description = "Database used as the baseline for the diff")
@@ -88,10 +92,12 @@ public class Diff extends AbstractExecScript implements RunnableTask<ScriptOutpu
 
     @Schema(title = "Reference username", description = "Authentication for the reference database; empty means driver default")
     @PluginProperty(secret = true, group = "connection")
+    @ToString.Exclude
     private Property<String> referenceUsername;
 
     @Schema(title = "Reference password", description = "Password for the reference user; stored as plain value in the task run")
     @PluginProperty(secret = true, group = "connection")
+    @ToString.Exclude
     private Property<String> referencePassword;
 
     @Schema(title = "Output changelog file (XML/SQL/JSON)", description = "When set, writes the diff to this file via `diff-changelog`; file type is inferred from extension")
@@ -116,27 +122,35 @@ public class Diff extends AbstractExecScript implements RunnableTask<ScriptOutpu
         TargetOS os = runContext.render(this.targetOS).as(TargetOS.class).orElse(null);
         boolean hasChangelog = runContext.render(changelogFile).as(String.class).isPresent();
 
-        String command = Stream.concat(
+        // Credentials are passed via environment variables (consumed natively by the
+        // Liquibase CLI as LIQUIBASE_COMMAND_* vars) rather than as CLI flags, so they
+        // never appear in the assembled command string, process arguments (/proc), or logs.
+        Map<String, String> secretEnv = new LinkedHashMap<>();
+        secretEnv.put("LIQUIBASE_COMMAND_PASSWORD", runContext.render(password).as(String.class).orElse(""));
+        secretEnv.put("LIQUIBASE_COMMAND_REFERENCE_PASSWORD", runContext.render(referencePassword).as(String.class).orElse(""));
+
+        List<String> commandParts = Stream.concat(
             Stream.of("liquibase", hasChangelog ? "diff-changelog" : "diff"),
             Stream.of(
                 "--url=" + runContext.render(url).as(String.class).orElseThrow(),
                 "--username=" + runContext.render(username).as(String.class).orElse(""),
-                "--password=" + runContext.render(password).as(String.class).orElse(""),
                 "--reference-url=" + runContext.render(referenceUrl).as(String.class).orElseThrow(),
-                "--reference-username=" + runContext.render(referenceUsername).as(String.class).orElse(""),
-                "--reference-password=" + runContext.render(referencePassword).as(String.class).orElse("")
+                "--reference-username=" + runContext.render(referenceUsername).as(String.class).orElse("")
             )
-        ).reduce((a, b) -> a + " " + b).orElseThrow();
+        ).collect(java.util.stream.Collectors.toCollection(java.util.ArrayList::new));
 
         if (hasChangelog) {
             String file = runContext.render(changelogFile).as(String.class).orElseThrow();
-            command += " --changelog-file=" + file;
+            commandParts.add("--changelog-file=" + file);
         }
+
+        String command = String.join(" ", commandParts);
 
         return this.commands(runContext)
             .withTaskRunner(this.taskRunner)
             .withContainerImage(runContext.render(this.containerImage).as(String.class).orElse(DEFAULT_IMAGE))
             .withInterpreter(this.interpreter)
+            .addEnv(secretEnv)
             .withCommands(Property.ofValue(List.of(command)))
             .withTargetOS(os)
             .run();


### PR DESCRIPTION
## Summary

Remediates all findings (CRITICAL/HIGH/MEDIUM/LOW) from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** — Database passwords inlined into shell command string in `Diff.run()` — `src/main/java/io/kestra/plugin/liquibase/Diff.java:118`. Passwords (`password`, `referencePassword`) are no longer concatenated into the assembled CLI command string. They are now passed to the task runner via environment variables (`LIQUIBASE_COMMAND_PASSWORD` / `LIQUIBASE_COMMAND_REFERENCE_PASSWORD`), which Liquibase consumes natively, so credentials never appear in the loggable command string or in `/proc` process arguments.
- **MEDIUM** — `@ToString` on `Diff` exposes secret credential fields via Lombok-generated `toString()` — `src/main/java/io/kestra/plugin/liquibase/Diff.java:27`. Added `@ToString.Exclude` to all `secret = true` fields (`username`, `password`, `referenceUsername`, `referencePassword`) so they are omitted from the generated `toString()` output.
- **LOW** — Plaintext credentials in embedded `@Plugin` example snippets — `src/main/java/io/kestra/plugin/liquibase/CLI.java:55` (and the same pattern at lines 83 and 119). Replaced hardcoded `--password=pass1` / `--reference-password=pass2` literals in all three documentation examples with `{{ secret('DB_PASSWORD') }}` / `{{ secret('REFERENCE_DB_PASSWORD') }}` placeholders, consistent with the secure pattern already used in `Diff.java`'s example.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-liquibase/issues/66
- [Full Audit Report](https://claude.ai/code/artifact/87ba8c38-c7ec-40ef-8d8e-384da1bfacf4)
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)
