### PR TITLE
ci: raise Gradle daemon heap to fix submit-gradle OOM

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 version=1.3.4-SNAPSHOT
 kestraVersion=1.3.13
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=768m


### PR DESCRIPTION
The `submit-gradle` (dependency-graph submission) job consistently fails with `java.lang.OutOfMemoryError: Java heap space`. It runs the Gradle daemon at the default 512 MiB heap and OOMs during dependency resolution — reproducibly, across all open Dependabot PRs. The real build gates (`check / main`, `Java Tests Report`) pass; only the dep-graph submission fails.

This sets `org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=768m` so the daemon has enough headroom.

Once this lands, the open Gradle Dependabot PRs (#59, #61, #64, #65) can be rebased and merged with green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)